### PR TITLE
Upgrade to SFML3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,28 @@ cmake_minimum_required(VERSION 3.12)
 
 project(Candle)
 
-# set C++11 standard
-set(CMAKE_CXX_STANDARD 11)
+# set C++17 standard
+set(CMAKE_CXX_STANDARD 17)
 
 # set output files directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib)
 
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 
 # might need to set manually SFML_ROOT to the install location of SFML for Windows users
-# set(SFML_ROOT "")
-if(SFML_ROOT STREQUAL "")
-	find_package(SFML 2.5 REQUIRED COMPONENTS  graphics)
-endif()
+set(SFML_DIR "C:/Users/Corey/source/repos/SFML-3.0.0x64/lib/cmake/SFML")
+#if(SFML_ROOT STREQUAL "")
+	find_package(SFML 3.0.0 REQUIRED COMPONENTS  System Graphics)
+#endif()
 
 # if the user wants to use static SFML libs
 # set(SFML_STATIC_LIBRARIES TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,18 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.28)
+project(Candle LANGUAGES CXX)
 
-project(Candle)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
-# set C++17 standard
-set(CMAKE_CXX_STANDARD 17)
+include(FetchContent)
+FetchContent_Declare(SFML
+    GIT_REPOSITORY https://github.com/SFML/SFML.git
+    GIT_TAG 3.0.x
+    GIT_SHALLOW ON
+    EXCLUDE_FROM_ALL
+    SYSTEM)
+FetchContent_MakeAvailable(SFML)
 
-# set output files directories
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib)
-
-# Set a default build type if none was specified
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
-
-
-# might need to set manually SFML_ROOT to the install location of SFML for Windows users
-# set(SFML_DIR "C:/Path/To/SFML3/lib/cmake/SFML")
-if(SFML_ROOT STREQUAL "")
-	find_package(SFML 3.0.0 REQUIRED COMPONENTS  System Graphics)
-endif()
-
-# if the user wants to use static SFML libs
-# set(SFML_STATIC_LIBRARIES TRUE)
 
 set(CANDLE_HEADERS
 	include/Candle/LightingArea.hpp
@@ -53,17 +39,16 @@ set(CANDLE_SRC
 	src/Constants.cpp
 )
 
-# Static library target
 add_library(Candle-s STATIC ${CANDLE_SRC} ${CANDLE_HEADERS})
 target_include_directories(Candle-s PUBLIC include)
-target_link_libraries(Candle-s sfml-graphics sfml-system)
+target_link_libraries(Candle-s PRIVATE SFML::Graphics)
+target_compile_features(Candle-s PRIVATE cxx_std_17)
 
 option(RADIAL_LIGHT_FIX "Use RadialLight fix for errors with textures" OFF)
 
 if(RADIAL_LIGHT_FIX)
 	target_compile_definitions(Candle-s PUBLIC -DRADIAL_LIGHT_FIX)
 endif()
-
 
 # Demo target
 option(BUILD_DEMO "Build demo application" OFF)
@@ -72,5 +57,6 @@ if (BUILD_DEMO)
 	set(DEMO_SRC demo.cpp)
 	add_executable(demo ${DEMO_SRC})
 	target_include_directories(demo PRIVATE include)
-	target_link_libraries(demo PRIVATE sfml-graphics Candle-s)
+	target_link_libraries(demo PRIVATE SFML::Graphics Candle-s)
+	target_compile_features(demo PRIVATE cxx_std_17)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ endif()
 
 
 # might need to set manually SFML_ROOT to the install location of SFML for Windows users
-set(SFML_DIR "C:/Users/Corey/source/repos/SFML-3.0.0x64/lib/cmake/SFML")
-#if(SFML_ROOT STREQUAL "")
+# set(SFML_DIR "C:/Path/To/SFML3/lib/cmake/SFML")
+if(SFML_ROOT STREQUAL "")
 	find_package(SFML 3.0.0 REQUIRED COMPONENTS  System Graphics)
-#endif()
+endif()
 
 # if the user wants to use static SFML libs
 # set(SFML_STATIC_LIBRARIES TRUE)
@@ -56,7 +56,7 @@ set(CANDLE_SRC
 # Static library target
 add_library(Candle-s STATIC ${CANDLE_SRC} ${CANDLE_HEADERS})
 target_include_directories(Candle-s PUBLIC include)
-target_link_libraries(Candle-s sfml-graphics)
+target_link_libraries(Candle-s sfml-graphics sfml-system)
 
 option(RADIAL_LIGHT_FIX "Use RadialLight fix for errors with textures" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CANDLE_HEADERS
 	include/Candle/DirectedLight.hpp
 	include/Candle/geometry/Line.hpp
 	include/Candle/geometry/Polygon.hpp
-    include/Candle/geometry/Vector2.hpp
+        include/Candle/geometry/Vector2.hpp
 	include/Candle/graphics/Color.hpp
 	include/Candle/graphics/VertexArray.hpp
 	include/Candle/Constants.hpp
@@ -57,6 +57,6 @@ if (BUILD_DEMO)
 	set(DEMO_SRC demo.cpp)
 	add_executable(demo ${DEMO_SRC})
 	target_include_directories(demo PRIVATE include)
-	target_link_libraries(demo PRIVATE SFML::Graphics Candle-s)
+	target_link_libraries(demo PRIVATE SFML::Graphics SFML::System Candle-s)
 	target_compile_features(demo PRIVATE cxx_std_17)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<h3>Candle-SFML3</h3>
+<p>This is a port of Candle to SFML3. No additional work/modification/upgrades have been added other than getting the project to compile and run. It has been successfully integrated into an existing SFML3 project, but not all features have been tested.</p>
+
+<p>The only major change to note, though it should not affect existing projects, is that with the deprecation and removal of sf::Quads as a Primitive Type for Vertex Arrays, LightingArea and DirectedLight have had their Vertex Arrays adjusted to use sf::PrimitiveType::Triangles instead. They should function the same, as far as the user is concerned.</p>
+
+<p>The original ReadMe is below.</p>
+
 <p align="center"><a href="https://miguelmj.github.io/Candle"><img src="doc/logo.svg" alt="logo" height="200px"/></a></p>
 <h1 align="center">Candle</h1>
 <h3 align="center">2D lighting for SFML</h3>

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+﻿#include <iostream>
 #include <iomanip>
 #include <memory>
 #include <ctime>
@@ -85,7 +85,7 @@ struct App{
             rect.setOutlineColor(buttonZ2);
             rect.setOutlineThickness(2);
             rect.setSize({bw, bw});
-            setPosition(2, 2 + (BC)*(bw + 4));
+            setPosition({ 2, 2 + (BC) * (bw + 4) });
             icon = d;
             function = f;
             BC++;
@@ -121,28 +121,28 @@ struct App{
     App()
     : lighting(candle::LightingArea::FOG, {0.f,0.f}, {WIDTH, HEIGHT})
     {
-        w.create(sf::VideoMode(WIDTH+MENU_W, HEIGHT), "Candle - demo");
+        w.create(sf::VideoMode({ uint16_t(WIDTH + MENU_W), uint16_t(HEIGHT) }), "Candle - demo");
         w.setFramerateLimit(60);
         float totalWidth = WIDTH + MENU_W;
-        edgeVertices.setPrimitiveType(sf::Lines);
-        background.setPrimitiveType(sf::Quads);
+        edgeVertices.setPrimitiveType(sf::PrimitiveType::Lines);
+        background.setPrimitiveType(sf::PrimitiveType::Triangles);
         background.resize(ROWS * COLS * 4);
         if(fogTex.loadFromFile("texture.png")){
             lighting.setAreaTexture(&fogTex);
-            lighting.scale(WIDTH/fogTex.getSize().x, HEIGHT/fogTex.getSize().y);
+            lighting.scale({ WIDTH / fogTex.getSize().x, HEIGHT / fogTex.getSize().y });
         }else{
             std::cout << "No texture detected" << std::endl;
             lighting.setAreaColor(sf::Color::Black);
         }
         lighting.clear();
-        mouseBlock.setPrimitiveType(sf::Lines);
+        mouseBlock.setPrimitiveType(sf::PrimitiveType::Lines);
         mouseBlock.resize(8);
-        sandboxView.setSize(WIDTH, HEIGHT);
-        sandboxView.setCenter(WIDTH/2.f, HEIGHT/2.f);
-        sandboxView.setViewport({0.f, 0.f, WIDTH/totalWidth, 1.f});
-        menuView.setSize(MENU_W, HEIGHT);
-        menuView.setCenter(MENU_W/2, HEIGHT/2);
-        menuView.setViewport({WIDTH/totalWidth, 0.f, MENU_W/totalWidth, 1.f});
+        sandboxView.setSize({ WIDTH, HEIGHT });
+        sandboxView.setCenter({ WIDTH / 2.f, HEIGHT / 2.f });
+        sandboxView.setViewport({ {0.f, 0.f}, {WIDTH / totalWidth, 1.f } });
+        menuView.setSize({ MENU_W, HEIGHT });
+        menuView.setCenter({ MENU_W / 2, HEIGHT / 2 });
+        menuView.setViewport({ {WIDTH / totalWidth, 0.f}, {MENU_W / totalWidth, 1.f } });
         radialLight.setRange(100.f);
         directedLight.setRange(200.f);
         directedLight.setBeamWidth(200.f);
@@ -179,74 +179,103 @@ struct App{
         i1->setFillColor({255,255,150,255});
         i1->setOutlineColor(sf::Color::White);
         i1->setOutlineThickness(2);
-        i1->move(MENU_W/6, MENU_W/6);
+        i1->move({ MENU_W / 6, MENU_W / 6 });
         buttons.emplace_back(i1, [](App* app){ app->setBrush(RADIAL); });
         
         auto i2 = new sf::RectangleShape({MENU_W*2/3, MENU_W/2});
-        i2->move(MENU_W/6, MENU_W/4);
+        i2->move({ MENU_W / 6, MENU_W / 4 });
         i2->setFillColor({255,255,150,255});
         i2->setOutlineColor(sf::Color::White);
         i2->setOutlineThickness(1);
         buttons.emplace_back(i2, [](App* app){ app->setBrush(DIRECTED); });
         
         auto i3 = new sf::RectangleShape({MENU_W/2, MENU_W/2});
-        i3->move(MENU_W/4, MENU_W/4);
+        i3->move({ MENU_W / 4, MENU_W / 4 });
         i3->setFillColor({25,25,25,255});
         buttons.emplace_back(i3, [](App* app){ app->setBrush(BLOCK); });
         
         auto i4 = new sf::RectangleShape({MENU_W, 3});
-        i4->move(MENU_W*2/15, MENU_W*2/15);
-        i4->rotate(45.f);
+        i4->move({ MENU_W * 2 / 15, MENU_W * 2 / 15 });
+        i4->rotate(sf::degrees(45.f));
         i4->setFillColor({25,25,25,255});
         buttons.emplace_back(i4, [](App* app){ app->setBrush(LINE); });
         
-        auto  i7 = new sf::VertexArray(sf::Quads, 12);
-        for(int i=0; i < 12; i++){
-            (*i7)[i] = background[i];
+        auto i7 = new sf::VertexArray(sf::PrimitiveType::Triangles, 18); // 3 vertices * 6 triangles (from 3 quads)
+        for (int q = 0; q < 3; ++q) {
+            int base = q * 4;
+            int tri = q * 6;
+            (*i7)[tri + 0] = background[base + 0];
+            (*i7)[tri + 1] = background[base + 1];
+            (*i7)[tri + 2] = background[base + 2];
+            (*i7)[tri + 3] = background[base + 0];
+            (*i7)[tri + 4] = background[base + 2];
+            (*i7)[tri + 5] = background[base + 3];
         }
-        sfu::transform(*i7, {MENU_W*2/7/CELL_W, 0, MENU_W/14 - 1,
-                            0, MENU_W*2/7/CELL_H, MENU_W*5/14 - 1,
-                            0, 0, 1
-                            });
+        sfu::transform(*i7, {
+            MENU_W * 2 / 7 / CELL_W, 0, MENU_W / 14 - 1,
+            0, MENU_W * 2 / 7 / CELL_H, MENU_W * 5 / 14 - 1,
+            0, 0, 1
+            });
         sfu::darken(*i7, 0.2);
-        buttons.emplace_back(i7, [](App *app){ app->lighting.setAreaOpacity(clamp(app->lighting.getAreaOpacity() - 0.1)); });
-        
-        auto  i8 = new sf::VertexArray(*i7);
+        buttons.emplace_back(i7, [](App* app) {
+            app->lighting.setAreaOpacity(clamp(app->lighting.getAreaOpacity() - 0.1));
+            });
+
+        auto i8 = new sf::VertexArray(*i7);
         sfu::darken(*i8, 0.5);
-        buttons.emplace_back(i8, [](App *app){ app->lighting.setAreaOpacity(clamp(app->lighting.getAreaOpacity() + 0.1)); });
+        buttons.emplace_back(i8, [](App* app) {
+            app->lighting.setAreaOpacity(clamp(app->lighting.getAreaOpacity() + 0.1));
+            });
+
         
-        auto i5 = new sf::VertexArray(sf::Quads, 8);
-        (*i5)[0].position = {1, 0};
-        (*i5)[1].position = {2, 0};
-        (*i5)[2].position = {2, 3};
-        (*i5)[3].position = {1, 3};
-        (*i5)[4].position = {0, 1};
-        (*i5)[5].position = {3, 1};
-        (*i5)[6].position = {3, 2};
-        (*i5)[7].position = {0, 2};
-        sfu::setColor(*i5, {255,255,150,255});
-        float a = sfu::PI/4;
-        float s = MENU_W*2/9;
-        sfu::transform(*i5, {s*std::cos(a), s*-std::sin(a), MENU_W/2,
-                            s*std::sin(a), s*std::cos(a), 0,
-                            0, 0, 1
-                            });
-        buttons.emplace_back(i5, [](App* app){ app->clearLights(); });
-        
+        auto i5 = new sf::VertexArray(sf::PrimitiveType::Triangles, 12); // 2 quads → 4 triangles → 12 vertices
+
+        // First quad (1,0)-(2,0)-(2,3)-(1,3)
+        (*i5)[0].position = { 1, 0 };
+        (*i5)[1].position = { 2, 0 };
+        (*i5)[2].position = { 2, 3 };
+        (*i5)[3].position = { 1, 0 };
+        (*i5)[4].position = { 2, 3 };
+        (*i5)[5].position = { 1, 3 };
+
+        // Second quad (0,1)-(3,1)-(3,2)-(0,2)
+        (*i5)[6].position = { 0, 1 };
+        (*i5)[7].position = { 3, 1 };
+        (*i5)[8].position = { 3, 2 };
+        (*i5)[9].position = { 0, 1 };
+        (*i5)[10].position = { 3, 2 };
+        (*i5)[11].position = { 0, 2 };
+
+        sfu::setColor(*i5, { 255, 255, 150, 255 });
+        float a = sfu::PI / 4;
+        float s = MENU_W * 2 / 9;
+        sfu::transform(*i5, {
+            s * std::cos(a), s * -std::sin(a), MENU_W / 2,
+            s * std::sin(a), s * std::cos(a), 0,
+            0, 0, 1
+            });
+        buttons.emplace_back(i5, [](App* app) {
+            app->clearLights();
+            });
+
         auto i6 = new sf::VertexArray(*i5);
-        sfu::setColor(*i6, {25,25,25,255});
-        buttons.emplace_back(i6, [](App *app){ app->clearEdges(); app->castAllLights(); });
+        sfu::setColor(*i6, { 25, 25, 25, 255 });
+        buttons.emplace_back(i6, [](App* app) {
+            app->clearEdges();
+            app->castAllLights();
+            });
+
         
         
         
     }
     void capture(){
         sf::Texture tex;
-        tex.create(w.getSize().x, w.getSize().y);
+        if (!tex.resize({ w.getSize().x, w.getSize().y })) throw std::runtime_error("Error resizing texture!");
         tex.update(w);
         
         sf::RenderTexture rt;
-        rt.create(WIDTH, HEIGHT);
+		if (!rt.resize({ uint16_t(WIDTH), uint16_t(HEIGHT) })) throw std::runtime_error("Error resizing render texture!");
         rt.setView(sf::View({WIDTH/2, HEIGHT/2}, {WIDTH, HEIGHT}));
         rt.draw(sf::Sprite(tex));
         rt.display();
@@ -285,8 +314,8 @@ struct App{
     }
     void pushEdge(const sfu::Line& edge){
         edgePool.push_back(edge);
-        edgeVertices.append(sf::Vertex(edge.m_origin));
-        edgeVertices.append(sf::Vertex(edge.point(1.f)));
+        edgeVertices.append(sf::Vertex({ edge.m_origin }));
+        edgeVertices.append(sf::Vertex({ edge.point(1.f) }));
     }
     void popEdge(){
         edgePool.pop_back();
@@ -425,7 +454,7 @@ struct App{
             switch(brush){
             case RADIAL:
                 if(alt){
-                    radialLight.rotate(d*6);
+                    radialLight.rotate(sf::degrees(6 * d));
                 }else if(shift){
                     radialLight.setBeamAngle(radialLight.getBeamAngle() + d*5);
                 }else{
@@ -435,7 +464,7 @@ struct App{
                 break;
             case DIRECTED:
                 if(alt){
-                    directedLight.rotate(6 * d);
+                    directedLight.rotate(sf::degrees(6 * d));
                 }else if(shift){
                     directedLight.setBeamWidth(directedLight.getBeamWidth() + d*5);
                 }else{
@@ -453,7 +482,7 @@ struct App{
     }
     void updateOnPressKey(sf::Keyboard::Key k){
         switch(k){
-        case sf::Keyboard::M:{
+        case sf::Keyboard::Key::M:{
                 bool textured = lighting.getAreaTexture() != nullptr;
                 if(lighting.getMode() == candle::LightingArea::FOG){
                     lighting.setMode(candle::LightingArea::AMBIENT);
@@ -464,67 +493,67 @@ struct App{
                 }
             }
             break;
-        case sf::Keyboard::T:
+        case sf::Keyboard::Key::T:
             persistent_fog = !persistent_fog;
             break;
-        case sf::Keyboard::P:
+        case sf::Keyboard::Key::P:
             capture();
             break;
-        case sf::Keyboard::Q:
-        case sf::Keyboard::Escape:
+        case sf::Keyboard::Key::Q:
+        case sf::Keyboard::Key::Escape:
             w.close();
             break;
-        case sf::Keyboard::LControl:
+        case sf::Keyboard::Key::LControl:
             control = true;
             break;
-        case sf::Keyboard::LAlt:
+        case sf::Keyboard::Key::LAlt:
             alt = true;
             break;
-        case sf::Keyboard::LShift:
+        case sf::Keyboard::Key::LShift:
             shift = true;
             break;
-        case sf::Keyboard::R:
+        case sf::Keyboard::Key::R:
             setBrush(RADIAL);
             break;
-        case sf::Keyboard::D:
+        case sf::Keyboard::Key::D:
             setBrush(DIRECTED);
             break;
-        case sf::Keyboard::B:
+        case sf::Keyboard::Key::B:
             setBrush(BLOCK);
             break;
-        case sf::Keyboard::L:
+        case sf::Keyboard::Key::L:
             setBrush(LINE);
             break;
-        case sf::Keyboard::A:
+        case sf::Keyboard::Key::A:
             lighting.setAreaOpacity(clamp(lighting.getAreaOpacity()+0.1));
             break;
-        case sf::Keyboard::Z:
+        case sf::Keyboard::Key::Z:
             lighting.setAreaOpacity(clamp(lighting.getAreaOpacity()-0.1));
             break;
-        case sf::Keyboard::S:
+        case sf::Keyboard::Key::S:
             if(brush == RADIAL || brush == DIRECTED){
                 radialLight.setIntensity(clamp(radialLight.getIntensity()+0.1));
                 directedLight.setIntensity(clamp(directedLight.getIntensity()+0.1));
             }
             break;
-        case sf::Keyboard::X:
+        case sf::Keyboard::Key::X:
             if(brush == RADIAL || brush == DIRECTED){
                 radialLight.setIntensity(clamp(radialLight.getIntensity()-0.1));
                 directedLight.setIntensity(clamp(directedLight.getIntensity()-0.1));
             }
             break;
-        case sf::Keyboard::G:
+        case sf::Keyboard::Key::G:
             if(brush == RADIAL || brush == DIRECTED){
                 glow = !glow;
             }
             break;
-        case sf::Keyboard::F:
+        case sf::Keyboard::Key::F:
             if(brush == RADIAL || brush == DIRECTED){
                 radialLight.setFade(!radialLight.getFade());
                 directedLight.setFade(!directedLight.getFade());
             }
             break;
-        case sf::Keyboard::C:
+        case sf::Keyboard::Key::C:
             if(brush == RADIAL || brush == DIRECTED){
                 static const sf::Color L_COLORS[] = {
                     sf::Color::White,
@@ -539,7 +568,7 @@ struct App{
                 directedLight.setColor(L_COLORS[color_i]);
             }
             break;
-        case sf::Keyboard::Space:
+        case sf::Keyboard::Key::Space:
             lineStarted = false;
             if(alt){
                 clearEdges();
@@ -556,13 +585,13 @@ struct App{
     }
     void updateOnReleaseKey(sf::Keyboard::Key k){
         switch(k){
-        case sf::Keyboard::LControl:
+        case sf::Keyboard::Key::LControl:
             control = false;
             break;
-        case sf::Keyboard::LAlt:
+        case sf::Keyboard::Key::LAlt:
             alt = false;
             break;
-        case sf::Keyboard::LShift:
+        case sf::Keyboard::Key::LShift:
             shift = false;
             break;
         default:
@@ -586,43 +615,39 @@ struct App{
     void mainLoop(){
         //candle::initializeTextures();
         sf::Clock clock;
-        while(w.isOpen()){
-            sf::Event e;
-            while(w.pollEvent(e)){
-                switch(e.type){
-                case sf::Event::Closed:
+        while (w.isOpen()) {
+            while (const std::optional event = w.pollEvent()) {
+                if (event->is<sf::Event::Closed>()) {
                     w.close();
-                    break;
-                case sf::Event::MouseMoved:
+                }
+                else if (const auto* mouseMoved = event->getIf<sf::Event::MouseMoved>()) {
                     updateOnMouseMove();
-                    break;
-                case sf::Event::MouseWheelScrolled:
-                    updateOnMouseScroll((0 < e.mouseWheelScroll.delta) - (e.mouseWheelScroll.delta < 0));
-                    break;
-                case sf::Event::KeyPressed:
-                    updateOnPressKey(e.key.code);
-                    break;
-                case sf::Event::KeyReleased:
-                    updateOnReleaseKey(e.key.code);
-                    break;
-                case sf::Event::MouseButtonPressed:
-                    if(e.mouseButton.button == sf::Mouse::Left){
+                }
+                else if (const auto* mouseScrolled = event->getIf<sf::Event::MouseWheelScrolled>()) {
+                    updateOnMouseScroll((0 < mouseScrolled->delta) - (mouseScrolled->delta < 0));
+                }
+                else if (const auto* keyPressed = event->getIf<sf::Event::KeyPressed>()) {
+                    updateOnPressKey(keyPressed->code);
+                }
+                else if (const auto* keyReleased = event->getIf<sf::Event::KeyReleased>()) {
+                    updateOnReleaseKey(keyReleased->code);
+                }
+                else if (const auto* mousePressed = event->getIf<sf::Event::MouseButtonPressed>()) {
+                    if (mousePressed->button == sf::Mouse::Button::Left) {
                         click();
-                    }else{
+                    }
+                    else {
                         setBrush(NONE);
                     }
-                    break;
-                case sf::Event::MouseButtonReleased:
-                    if(e.mouseButton.button == sf::Mouse::Left){
+                }
+                else if (const auto* mouseReleased = event->getIf<sf::Event::MouseButtonReleased>()) {
+                    if (mouseReleased->button == sf::Mouse::Button::Left) {
                         lineStarted = false;
-                        for(auto& b: buttons){
+                        for (auto& b : buttons) {
                             b.rect.setFillColor(Button::buttonZ1);
                             b.rect.setOutlineColor(Button::buttonZ2);
                         }
                     }
-                    break;
-                default:
-                    break;
                 }
             }
             

--- a/include/Candle/LightingArea.hpp
+++ b/include/Candle/LightingArea.hpp
@@ -79,11 +79,9 @@ namespace candle{
     private:
         const sf::Texture* m_baseTexture;
         sf::IntRect m_baseTextureRect;
-        sf::VertexArray m_baseTextureTriangle1; // Use two Triangles to represent one Quad
-        sf::VertexArray m_baseTextureTriangle2;
+        sf::VertexArray m_baseTextureTriangles;
         sf::RenderTexture m_renderTexture;
-        sf::VertexArray m_areaTriangle1;
-        sf::VertexArray m_areaTriangle2;
+        sf::VertexArray m_areaTriangles;
         sf::Color m_color;
         uint8_t m_opacity;
         sf::Vector2f m_size;

--- a/include/Candle/LightingArea.hpp
+++ b/include/Candle/LightingArea.hpp
@@ -79,11 +79,13 @@ namespace candle{
     private:
         const sf::Texture* m_baseTexture;
         sf::IntRect m_baseTextureRect;
-        sf::VertexArray m_baseTextureQuad;
+        sf::VertexArray m_baseTextureTriangle1; // Use two Triangles to represent one Quad
+        sf::VertexArray m_baseTextureTriangle2;
         sf::RenderTexture m_renderTexture;
-        sf::VertexArray m_areaQuad;
+        sf::VertexArray m_areaTriangle1;
+        sf::VertexArray m_areaTriangle2;
         sf::Color m_color;
-        float m_opacity;
+        uint8_t m_opacity;
         sf::Vector2f m_size;
         Mode m_mode;
         /**
@@ -113,7 +115,7 @@ namespace candle{
          * @param texture
          * @param rect
          */
-        LightingArea(Mode mode, const sf::Texture* texture, sf::IntRect rect=sf::IntRect());
+        LightingArea(Mode mode, const sf::Texture* texture, sf::FloatRect rect=sf::FloatRect());
         
         /**
          * @brief Get the local bounding rectangle of the area.
@@ -158,7 +160,7 @@ namespace candle{
          * @param opacity
          * @see getAreaOpacity, setAreaColor
          */
-        void setAreaOpacity(float opacity);
+        void setAreaOpacity(uint8_t opacity);
         
         /**
          * @brief Get the opacity of the fog/light.
@@ -175,7 +177,7 @@ namespace candle{
          * is specified, the whole texture is used.
          * @see getAreaTexture
          */
-        void setAreaTexture(const sf::Texture* texture, sf::IntRect rect=sf::IntRect());
+        void setAreaTexture(const sf::Texture* texture, sf::FloatRect rect=sf::FloatRect());
         
         /**
          * @brief Get the texture of the fog/light.
@@ -191,7 +193,7 @@ namespace candle{
          * @param rect
          * @see getTextureRect
          */
-        void setTextureRect(const sf::IntRect& rect);
+        void setTextureRect(const sf::FloatRect& rect);
         
         /**
          * @brief Get the rectangle of the used sub-section of the texture.

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -2,15 +2,15 @@
 
 namespace sfu{
     sf::Color darken(const sf::Color& c, float r){
-        return sf::Color(c.r * (1.f-r), c.g * (1.f-r), c.b * (1.f-r), c.a);
+        return sf::Color(uint8_t(c.r * (1.f-r)), uint8_t(c.g * (1.f-r)), uint8_t(c.b * (1.f-r)), c.a);
     }
     
     sf::Color lighten(const sf::Color& c, float r){
-        return sf::Color(c.r * (1.f+r), c.g * (1.f+r), c.b * (1.f+r), c.a);
+        return sf::Color(uint8_t(c.r * (1.f+r)), uint8_t(c.g * (1.f+r)), uint8_t(c.b * (1.f+r)), c.a);
     }
     
     sf::Color interpolate(const sf::Color& c1, const sf::Color& c2, float r){
-        return sf::Color(c1.r + (c2.r - c1.r) * r, c1.g + (c2.g - c1.g) * r, c1.b + (c2.b - c1.b) * r, c1.a + (c2.a - c1.a) * r);
+        return sf::Color(uint8_t(c1.r + (c2.r - c1.r) * r), uint8_t(c1.g + (c2.g - c1.g) * r), uint8_t(c1.b + (c2.b - c1.b) * r), uint8_t(c1.a + (c2.a - c1.a) * r));
     }
     
     sf::Color complementary(const sf::Color& c){

--- a/src/LightSource.cpp
+++ b/src/LightSource.cpp
@@ -17,7 +17,7 @@ namespace candle{
         {}
     
     void LightSource::setIntensity(float intensity){
-        m_color.a = 255 * intensity;
+        m_color.a = uint8_t(255 * intensity);
         resetColor();
     }
     

--- a/src/LightingArea.cpp
+++ b/src/LightingArea.cpp
@@ -15,7 +15,7 @@ namespace candle{
     
     void LightingArea::initializeRenderTexture(const sf::Vector2f& size){
         try { 
-            if (!m_renderTexture.resize({ uint16_t(size.x), uint16_t(size.y) }))
+            if (!m_renderTexture.resize({ uint32_t(size.x), uint32_t(size.y) }))
                 throw std::runtime_error("Failed to resize LightingArea RenderTexture!");
 
         }

--- a/src/LightingArea.cpp
+++ b/src/LightingArea.cpp
@@ -47,8 +47,8 @@ namespace candle{
     }
     
     LightingArea::LightingArea(Mode mode, const sf::Vector2f& position, const sf::Vector2f& size)
-    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangles(sf::PrimitiveType::Triangles, 3)
+    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 6)
+    , m_areaTriangles(sf::PrimitiveType::Triangles, 6)
     , m_color(sf::Color::White)
     {
         m_opacity = 1;
@@ -59,8 +59,8 @@ namespace candle{
     }
     
     LightingArea::LightingArea(Mode mode, const sf::Texture* t, sf::FloatRect r)
-    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangles(sf::PrimitiveType::Triangles, 3)
+    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 6)
+    , m_areaTriangles(sf::PrimitiveType::Triangles, 6)
     , m_color(sf::Color::White)
     {
         m_opacity = 1;

--- a/src/LightingArea.cpp
+++ b/src/LightingArea.cpp
@@ -11,7 +11,7 @@ namespace candle{
         sf::BlendMode::Equation::Add,             // color eq
         sf::BlendMode::Factor::Zero,              // alpha src
         sf::BlendMode::Factor::OneMinusSrcAlpha,  // alpha dst
-        sf::BlendMode::Equation::Add    );            // alpha eq
+        sf::BlendMode::Equation::Add);            // alpha eq
     
     void LightingArea::initializeRenderTexture(const sf::Vector2f& size){
         try { 
@@ -24,33 +24,31 @@ namespace candle{
         }
         m_renderTexture.setSmooth(true);
 
-        m_baseTextureTriangle1[0].position =
-        m_areaTriangle1[0].position =
-        m_areaTriangle1[0].texCoords = {0, 0};
-        m_baseTextureTriangle1[1].position =
-        m_areaTriangle1[1].position =
-        m_areaTriangle1[1].texCoords = {size.x, 0};
-        m_baseTextureTriangle1[2].position =
-        m_areaTriangle1[2].position =
-        m_areaTriangle1[2].texCoords = {size.x, size.y};
+        m_baseTextureTriangles[0].position =
+        m_areaTriangles[0].position =
+        m_areaTriangles[0].texCoords = {0, 0};
+        m_baseTextureTriangles[1].position =
+        m_areaTriangles[1].position =
+        m_areaTriangles[1].texCoords = {size.x, 0};
+        m_baseTextureTriangles[2].position =
+        m_areaTriangles[2].position =
+        m_areaTriangles[2].texCoords = {size.x, size.y};
 
-        m_baseTextureTriangle2[0].position =
-        m_areaTriangle2[0].position =
-        m_areaTriangle2[0].texCoords = { 0, 0 };
-        m_baseTextureTriangle2[1].position =
-        m_areaTriangle2[1].position =
-        m_areaTriangle2[1].texCoords = { size.x, size.y };
-        m_baseTextureTriangle2[2].position =
-        m_areaTriangle2[2].position =
-        m_areaTriangle2[2].texCoords = { 0, float(size.y) };
+        m_baseTextureTriangles[3].position =
+        m_areaTriangles[3].position =
+        m_areaTriangles[3].texCoords = { 0, 0 };
+        m_baseTextureTriangles[4].position =
+        m_areaTriangles[4].position =
+        m_areaTriangles[4].texCoords = { size.x, size.y };
+        m_baseTextureTriangles[5].position =
+        m_areaTriangles[5].position =
+        m_areaTriangles[5].texCoords = { 0, float(size.y) };
 
     }
     
     LightingArea::LightingArea(Mode mode, const sf::Vector2f& position, const sf::Vector2f& size)
-    : m_baseTextureTriangle1(sf::PrimitiveType::Triangles, 3)
-    , m_baseTextureTriangle2(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangle1(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangle2(sf::PrimitiveType::Triangles, 3)
+    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 3)
+    , m_areaTriangles(sf::PrimitiveType::Triangles, 3)
     , m_color(sf::Color::White)
     {
         m_opacity = 1;
@@ -61,10 +59,8 @@ namespace candle{
     }
     
     LightingArea::LightingArea(Mode mode, const sf::Texture* t, sf::FloatRect r)
-    : m_baseTextureTriangle1(sf::PrimitiveType::Triangles, 3)
-    , m_baseTextureTriangle2(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangle1(sf::PrimitiveType::Triangles, 3)
-    , m_areaTriangle2(sf::PrimitiveType::Triangles, 3)
+    : m_baseTextureTriangles(sf::PrimitiveType::Triangles, 3)
+    , m_areaTriangles(sf::PrimitiveType::Triangles, 3)
     , m_color(sf::Color::White)
     {
         m_opacity = 1;
@@ -73,17 +69,11 @@ namespace candle{
     }
     
     sf::FloatRect LightingArea::getLocalBounds () const{
-        // Because m_areaTriangle1's bounds include the top left 
-        // and bottom right corner of the "Quad" we're representing,
-        // we can simply return its bounds as an adequate stand-in.
-        return m_areaTriangle1.getBounds();
+        return m_areaTriangles.getBounds();
     }
     
     sf::FloatRect LightingArea::getGlobalBounds () const{
-        // Because m_areaTriangle1's bounds include the top left 
-        // and bottom right corner of the "Quad" we're representing,
-        // we can simply return its bounds as an adequate stand-in.
-        return Transformable::getTransform().transformRect(m_areaTriangle1.getBounds());
+        return Transformable::getTransform().transformRect(m_areaTriangles.getBounds());
     }
     
     void  LightingArea::draw(sf::RenderTarget& t, sf::RenderStates s) const{
@@ -93,16 +83,14 @@ namespace candle{
             }
             s.transform *= Transformable::getTransform();
             s.texture = &m_renderTexture.getTexture();
-            t.draw(m_areaTriangle1, s);
-            t.draw(m_areaTriangle2, s);
+            t.draw(m_areaTriangles, s);
         }
     }
     
     void LightingArea::clear(){
         if(m_baseTexture != nullptr){
             m_renderTexture.clear(sf::Color::Transparent);
-            m_renderTexture.draw(m_baseTextureTriangle1, m_baseTexture);
-            m_renderTexture.draw(m_baseTextureTriangle2, m_baseTexture);
+            m_renderTexture.draw(m_baseTextureTriangles, m_baseTexture);
         }else{
             m_renderTexture.clear(getActualColor());
         }
@@ -110,8 +98,7 @@ namespace candle{
     
     void LightingArea::setAreaColor(sf::Color c){
         m_color = c;
-        sfu::setColor(m_baseTextureTriangle1, getActualColor());
-        sfu::setColor(m_baseTextureTriangle2, getActualColor());
+        sfu::setColor(m_baseTextureTriangles, getActualColor());
     }
     
     sf::Color LightingArea::getAreaColor() const{
@@ -126,8 +113,7 @@ namespace candle{
     
     void LightingArea::setAreaOpacity(uint8_t o){
         m_opacity = o;
-        sfu::setColor(m_baseTextureTriangle1, getActualColor());
-        sfu::setColor(m_baseTextureTriangle2, getActualColor());
+        sfu::setColor(m_baseTextureTriangles, getActualColor());
     }
     
     float LightingArea::getAreaOpacity() const{
@@ -149,7 +135,7 @@ namespace candle{
             rect.size.x = float(texture->getSize().x);
             rect.size.y = float(texture->getSize().y);
         }
-        initializeRenderTexture(sf::Vector2f(rect.size.x, rect.size.y));
+        initializeRenderTexture(rect.size);
         setTextureRect(rect);
     }
     
@@ -158,13 +144,12 @@ namespace candle{
     }
     
     void LightingArea::setTextureRect(const sf::FloatRect& rect){
-        m_baseTextureTriangle1[0].texCoords = sf::Vector2f(rect.position.x, rect.position.y);
-        m_baseTextureTriangle1[1].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y);
-        m_baseTextureTriangle1[2].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y + rect.size.y);
-
-        m_baseTextureTriangle2[0].texCoords = sf::Vector2f(rect.position.x, rect.position.y);
-        m_baseTextureTriangle2[1].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y + rect.size.y);
-        m_baseTextureTriangle2[2].texCoords = sf::Vector2f(rect.position.x, rect.position.y + rect.size.y);
+        m_baseTextureTriangles[0].texCoords = sf::Vector2f(rect.position.x, rect.position.y);
+        m_baseTextureTriangles[1].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y);
+        m_baseTextureTriangles[2].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y + rect.size.y);
+        m_baseTextureTriangles[3].texCoords = sf::Vector2f(rect.position.x, rect.position.y);
+        m_baseTextureTriangles[4].texCoords = sf::Vector2f(rect.position.x + rect.size.x, rect.position.y + rect.size.y);
+        m_baseTextureTriangles[5].texCoords = sf::Vector2f(rect.position.x, rect.position.y + rect.size.y);
     }
     
     sf::IntRect LightingArea::getTextureRect() const{

--- a/src/Line.cpp
+++ b/src/Line.cpp
@@ -24,10 +24,10 @@ namespace sfu{
 
         //Make sure that the rectangle begin from the upper left corner
         sf::FloatRect rect;
-        rect.left = (point1.x < point2.x) ? point1.x : point2.x;
-        rect.top = (point1.y < point2.y) ? point1.y : point2.y;
-        rect.width = std::abs(m_direction.x) + 1.0f; //The +1 is here to avoid having a width of zero
-        rect.height = std::abs(m_direction.y) + 1.0f; //(SFML doesn't like 0 in rect)
+        rect.position.x = (point1.x < point2.x) ? point1.x : point2.x;
+        rect.position.y = (point1.y < point2.y) ? point1.y : point2.y;
+        rect.size.x = std::abs(m_direction.x) + 1.0f; //The +1 is here to avoid having a width of zero
+        rect.size.y = std::abs(m_direction.y) + 1.0f; //(SFML doesn't like 0 in rect)
 
         return rect;
     }

--- a/src/RadialLight.cpp
+++ b/src/RadialLight.cpp
@@ -25,8 +25,8 @@ namespace candle{
         l_lightTextureFade.reset(new sf::RenderTexture);
         l_lightTexturePlain.reset(new sf::RenderTexture);
         try {
-            if (!l_lightTextureFade->resize({ uint16_t(BASE_RADIUS * 2 + 2), uint16_t(BASE_RADIUS * 2 + 2) })) throw std::runtime_error("LightTextureFade resize failed!");
-            if (!l_lightTexturePlain->resize({ uint16_t(BASE_RADIUS * 2 + 2), uint16_t(BASE_RADIUS * 2 + 2) })) throw std::runtime_error("LightTextureFade resize failed!");
+            if (!l_lightTextureFade->resize({ uint32_t(BASE_RADIUS * 2 + 2), uint32_t(BASE_RADIUS * 2 + 2) })) throw std::runtime_error("LightTextureFade resize failed!");
+            if (!l_lightTexturePlain->resize({ uint32_t(BASE_RADIUS * 2 + 2), uint32_t(BASE_RADIUS * 2 + 2) })) throw std::runtime_error("LightTextureFade resize failed!");
         }
         catch (const std::exception& e) {
             std::cerr << "Render texture resize error: " << e.what() << std::endl;


### PR DESCRIPTION
This PR is an attempt to update Candle for use with SFML3. Most of the changes were minor, with the exception of refactoring sf::VertexArrays that were relying on sf::Quad (deprecated and removed) to instead use sf::PrimitiveType::Triangles.

I also updated the CMakeLists.txt file to be a more modern approach, but my Cmake knowledge is limited and I am definitely not 100% certain it's correct.